### PR TITLE
add cargo-apk and aarch64-linux-android target

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Once you have your dev shell setup, you can build with this command:
 $ cargo apk run --release 
 ```
 
-This will build and run the app on your android device.
+This will build and run the app on your android device. If you don't have the `aarch64-linux-android` rust target yet, you can install it with:
+
+```
+$ rustup target add aarch64-linux-android
+```
 
 You can also just type
 

--- a/shell.nix
+++ b/shell.nix
@@ -25,7 +25,7 @@ mkShell ({
 
     heaptrack
 
-  ] ++ pkgs.lib.optional use_android [ jre openssl libiconv androidsdk ] ;
+  ] ++ pkgs.lib.optional use_android [ jre openssl libiconv androidsdk cargo-apk ] ;
 
   LD_LIBRARY_PATH="${x11libs}";
 } // (if !use_android then {} else {


### PR DESCRIPTION
I tried the nix-shell and that's what was missing for me to build the apk. The desktop app worked out of the box.